### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # quickchart-server MCP Server
 
 ![image](https://github.com/user-attachments/assets/1093570f-7c6b-4e5f-ad69-f8a9f950376a)
+<a href="https://glama.ai/mcp/servers/y17zluizso">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/y17zluizso/badge" alt="Quickchart-MCP-Server MCP server" />
+</a>
 <a href="https://smithery.ai/server/@GongRzhe/Quickchart-MCP-Server"><img alt="Smithery Badge" src="https://smithery.ai/badge/@GongRzhe/Quickchart-MCP-Server"></a>
 
 ![](https://badge.mcpx.dev?type=server 'MCP Server')
@@ -132,4 +135,3 @@ The Inspector will provide a URL to access debugging tools in your browser.
 ## 📜 License
 
 This project is licensed under the MIT License.
-


### PR DESCRIPTION
This PR adds a badge for the [Quickchart-MCP-Server](https://glama.ai/mcp/servers/y17zluizso) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/y17zluizso">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/y17zluizso/badge" alt="Quickchart-MCP-Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.